### PR TITLE
Minimized required spec changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,41 +202,31 @@ model:
   tesTaskInfo:
     type: object
     properties:
-      costs_total:
+      compute_costs_estimate:
         $ref: '#/definitions/tesCosts'
         description: |-
           Estimated total incurred costs for running a task with the given
-          resource requirements on this TES instance.
-      costs_cpu_usage:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for CPU use.
-      costs_memory_consumption:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for memory consumption.
-      costs_data_storage:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for storage use.
-      costs_data_transfer:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Unit costs for transferring 1 GB of data across 1000 km.
-      queue_time:
-        $ref: '#/definitions/tesDuration'
+          resource requirements on this TES instance. Excludes any data transfer
+          costs.
+      queue_time_estimate_sec:
+        type: number
+        format: double
         description: |-
           Given the current load on this TES instance, returns an estimate of
-          the time that a task with the given resource requirements will spend
-          in the task queue.
+          the time, in seconds (s), that a task with the given resource
+          requirements will spend in the task queue.
+      unit_costs_data_transfer:
+        $ref: '#/definitions/tesCosts'
+        description: |-
+          Unit costs for transferring 1 gigabyte (GB) of data (inputs, outputs)
+          across 1000 kilometers (km).
     description: |-
       Given a set of resource requirements, returns the estimated queue time
       and total incurred costs. Allows informed decisions with regard to which
       TES instance a given task should be sent to.
 ```
 
-The response model relies on additional models `tesCosts` and `tesDuration`
-which are described as follows:
+The response model further relies on model `tesCosts`:
 
 ##### `tesCosts`
 
@@ -251,32 +241,29 @@ which are described as follows:
       currency:
         type: string
         enum:
-          - ARBITRARY
+          - AUD
+          - BRL
           - BTC
+          - CAD
+          - CHF
+          - CNH
           - EUR
+          - GBP
+          - HKD
+          - INR
+          - KRW
+          - JPY
+          - MXN
+          - NOK
+          - NZD
+          - RUB
+          - SEK
+          - SGD
+          - TRY
           - USD
+          - ZAR
         description: Currency/unit of the costs.
     description: Generic object specifying an amount of money.
-```
-
-##### `tesDuration`
-
-```yaml
-  tesDuration:
-    type: object
-    properties:
-      duration:
-        type: integer
-        format: int64
-        description: Integer value specifying a length of time.
-      unit:
-        type: string
-        enum:
-          - SECONDS
-          - MINUTES
-          - HOURS
-        description: Unit of the duration.
-    description: Generic object specifying a length of time.
 ```
 
 ### Service configuration

--- a/mock_tes/config/app_config.yaml
+++ b/mock_tes/config/app_config.yaml
@@ -11,8 +11,7 @@ openapi:
 
 # TES service settings
 task_info:
-    currency: ARBITRARY
-    time_unit: SECONDS
+    currency: BTC
     unit_costs:  # per min
         cpu_usage: 1  # per core
         memory_consumption: 1  # per GB

--- a/mock_tes/ga4gh/tes/server.py
+++ b/mock_tes/ga4gh/tes/server.py
@@ -64,20 +64,17 @@ def __get_task_info(resources, params):
         unit_costs_memory=params['unit_costs']['memory_consumption'],
         unit_costs_storage=params['unit_costs']['data_storage']
     )
-    queue_time = __get_queue_time(
-        resources=resources,
-        time_unit=params['time_unit']
-    )
+    queue_time = __get_queue_time()
     return {
-        'costs_total': costs['total'],
-        'costs_cpu_usage': costs['cpu_usage'],
-        'costs_memory_consumption': costs['memory_consumption'],
-        'costs_data_storage': costs['data_storage'],
-        'costs_data_transfer': {
-		'amount': params['unit_costs']['data_transfer'],
-		'currency': params['currency']
+        'compute_costs_estimate': {
+            'amount': costs['compute'],
+            'currency': params['currency'],
+        },
+        'unit_costs_data_transfer': {
+		    'amount': params['unit_costs']['data_transfer'],
+		    'currency': params['currency'],
 	},
-        'queue_time': queue_time
+        'queue_time_estimate_sec': queue_time
     }
 
 
@@ -98,17 +95,17 @@ def __get_compute_costs(
     mem = resources['ram_gb']
     size = resources['disk_gb']
 
-    # Calculate partial costs
+    # Calculate partial compute costs
     c_cores = t * cores * unit_costs_cores
     c_mem = t * mem * unit_costs_memory
     c_storage = t * size * unit_costs_storage
 
-    # Calculate total costs
+    # Calculate total compute costs
     c_total = c_cores + c_mem + c_storage
 
     # Return dictionary of tesCosts objects
     return {
-        'total': {
+        'compute': {
             'amount': c_total,
             'currency': currency
         },
@@ -127,17 +124,12 @@ def __get_compute_costs(
     }
 
 
-def __get_queue_time(resources, time_unit):
+def __get_queue_time():
     '''
     Helper function to estimate task queue time from tesResources object.
-    Returns a tesDuration object.
+    Returns a random float.
     '''
-    duration = randint(0, 3600)
-    unit = time_unit
-    return {
-        'duration': duration,
-        'unit': unit
-    }
+    return float(randint(0, 3600))
 
 
 def __update_task_info_config(config_new, config_old):

--- a/mock_tes/specs/schema.task_execution_service.config_update.openapi.yaml
+++ b/mock_tes/specs/schema.task_execution_service.config_update.openapi.yaml
@@ -24,37 +24,51 @@ definitions:
     properties:
       currency:
         type: string
-        enum: 
+        enum:
+          - AUD
+          - BRL
+          - BTC
+          - CAD
+          - CHF
+          - CNH
+          - EUR
+          - GBP
+          - HKD
+          - INR
+          - KRW
+          - JPY
+          - MXN
+          - NOK
+          - NZD
+          - RUB
+          - SEK
+          - SGD
+          - TRY
+          - USD
+          - ZAR
           - ARBITRARY
           - BTC
           - EUR
           - USD
         description: Currency/unit of the costs.
-      time_unit:
-        type: string
-        enum:
-          - SECONDS 
-          - MINUTES
-          - HOURS
-        description: Unit of the queue time.
       unit_costs:
         $ref: '#/definitions/tesTaskInfoCosts'
   tesTaskInfoCosts:
     type: object
     properties:
       cpu_usage:
-        type: integer
-        format: int64
+        type: number
+        format: double
         description: costs per core
       memory_consumption:
-        type: integer
-        format: int64
+        type: number
+        format: double
         description: costs of computation per GB
       data_storage:
-        type: integer
-        format: int64
+        type: number
+        format: double
         description:  cost of data storage  GB
       data_transfer:
-        type: integer
-        format: int64
+        type: number
+        format: double
         description: cost of data transfer per GB and 1000 km

--- a/mock_tes/specs/schema.task_execution_service.d55bf88.openapi.modified.yaml
+++ b/mock_tes/specs/schema.task_execution_service.d55bf88.openapi.modified.yaml
@@ -110,7 +110,6 @@ paths:
       operationId: GetTaskInfo
       responses:
         '200':
-          description: ''
           schema:
             $ref: '#/definitions/tesTaskInfo'
       parameters:
@@ -194,11 +193,28 @@ definitions:
         description: Numeric value specifying an amount of money.
       currency:
         type: string
-        enum: 
-          - ARBITRARY
+        enum:
+          - AUD
+          - BRL
           - BTC
+          - CAD
+          - CHF
+          - CNH
           - EUR
+          - GBP
+          - HKD
+          - INR
+          - KRW
+          - JPY
+          - MXN
+          - NOK
+          - NZD
+          - RUB
+          - SEK
+          - SGD
+          - TRY
           - USD
+          - ZAR
         description: Currency/unit of the costs.
     description: Generic object specifying an amount of money.
   tesCreateTaskResponse:
@@ -211,21 +227,6 @@ definitions:
     readOnly: true
     required:
     - id
-  tesDuration:
-    type: object
-    properties:
-      duration:
-        type: integer
-        format: int64
-        description: Integer value specifying a length of time.
-      unit:
-        type: string
-        enum:
-          - SECONDS 
-          - MINUTES
-          - HOURS
-        description: Unit of the duration.
-    description: Generic object specifying a length of time. 
   tesExecutor:
     type: object
     properties:
@@ -429,10 +430,10 @@ definitions:
   tesResources:
     type: object
     properties:
-      execution_time_min:
+      execution_time_sec:
         type: integer
         format: int64
-        description: Requested execution in minutes (min)
+        description: Requested execution in seconds (s)
       cpu_cores:
         type: integer
         format: int64
@@ -604,33 +605,24 @@ definitions:
   tesTaskInfo:
     type: object
     properties:
-      costs_total:
+      compute_costs_estimate:
         $ref: '#/definitions/tesCosts'
         description: |-
           Estimated total incurred costs for running a task with the given
-          resource requirements on this TES instance.
-      costs_cpu_usage:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for CPU use.
-      costs_memory_consumption:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for memory consumption.
-      costs_data_storage:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Estimated incurred costs for storage use.
-      costs_data_transfer:
-        $ref: '#/definitions/tesCosts'
-        description: |-
-          Unit costs for transferring 1 GB of data across 1000 km.
-      queue_time:
-        $ref: '#/definitions/tesDuration'
+          resource requirements on this TES instance. Excludes any data transfer
+          costs.
+      queue_time_estimate_sec:
+        type: number
+        format: double
         description: |-
           Given the current load on this TES instance, returns an estimate of
-          the time that a task with the given resource requirements will spend
-          in the task queue.
+          the time, in seconds (s), that a task with the given resource
+          requirements will spend in the task queue.
+      unit_costs_data_transfer:
+        $ref: '#/definitions/tesCosts'
+        description: |-
+          Unit costs for transferring 1 gigabyte (GB) of data (inputs, outputs)
+          across 1000 kilometers (km).
     description: |-
       Given a set of resource requirements, returns the estimated queue time
       and total incurred costs. Allows informed decisions with regard to which


### PR DESCRIPTION
- Renamed properties in `/tasks/task-info` response & removed partial costs to improve clarity
- Fixed queue time estimate unit to seconds & removed `tesDuration`
model
- Removed currency `ARBITRARY` and added currencies (now includes the
20 currencies with the highest market share plus BTC as an international
   option)
- Changed property `execution_time_min` to `execution_time_sec` to
reflect high resolution of most queuing systems
- Updated mock-TES and documentation accordingly